### PR TITLE
Added Placeholder image for images that are not defined

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -36,6 +36,13 @@ class Item extends React.Component {
       return null;
     }
 
+    // adds placeholder image if src not available
+    if (this.props.item.image) {
+      this.imgSrc = this.props.item.image;
+    } else {
+      this.imgSrc = "/placeholder.png";
+    }
+
     const markup = {
       __html: marked(this.props.item.description, { sanitize: true }),
     };
@@ -48,7 +55,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.imgSrc}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -29,6 +29,13 @@ const ItemPreview = (props) => {
     }
   };
 
+  // adds placeholder image if src not available
+  if (item.image) {
+    item.imgSrc = item.image;
+  } else {
+    item.imgSrc = "/placeholder.png";
+  }
+
   return (
     <div
       className="card bg-dark border-light p-3"
@@ -37,7 +44,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.imgSrc}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Items that don't have images now will show a placeholder image.

![image](https://user-images.githubusercontent.com/97260321/210124469-2f4a94b4-fd83-4d77-b9b1-af1af70f2ed5.png)

![image](https://user-images.githubusercontent.com/97260321/210124476-c22a48ee-22ff-48dc-8f7f-b07f1ebaaff3.png)
